### PR TITLE
Use native git instead of JGit for worktree support

### DIFF
--- a/src/main/scala/com/ossuminc/sbt/helpers/DynamicVersioning.scala
+++ b/src/main/scala/com/ossuminc/sbt/helpers/DynamicVersioning.scala
@@ -1,5 +1,6 @@
 package com.ossuminc.sbt.helpers
 
+import com.github.sbt.git.SbtGit.useReadableConsoleGit
 import sbt.*
 import sbtdynver.DynVerPlugin
 import sbtdynver.DynVerPlugin.autoImport.{dynverSeparator, dynverVTagPrefix}
@@ -26,6 +27,12 @@ object DynamicVersioning extends AutoPluginHelper {
         ThisBuild / dynverVTagPrefix := false,
 
         // use the minus character to separate version fields
-        ThisBuild / dynverSeparator := "-"
+        ThisBuild / dynverSeparator := "-",
+
+        // Use native git instead of JGit to support git worktrees.
+        // JGit doesn't properly handle worktrees (sees .git file as bare repo).
+        // Native git fully supports worktrees and is required for parallel
+        // development with multiple Claude workers in separate worktrees.
+        useReadableConsoleGit
       )
 }

--- a/src/main/scala/com/ossuminc/sbt/helpers/Git.scala
+++ b/src/main/scala/com/ossuminc/sbt/helpers/Git.scala
@@ -1,11 +1,20 @@
 package com.ossuminc.sbt.helpers
 
 import com.github.sbt.git.GitPlugin
+import com.github.sbt.git.SbtGit.useReadableConsoleGit
 import sbt._
 
 object Git extends AutoPluginHelper {
 
   def apply(project: Project): Project = {
-    project.enablePlugins(GitPlugin)
+    project
+      .enablePlugins(GitPlugin)
+      .settings(
+        // Use native git instead of JGit to support git worktrees.
+        // JGit doesn't properly handle worktrees (sees .git file as bare repo).
+        // Native git fully supports worktrees and is required for parallel
+        // development with multiple Claude workers in separate worktrees.
+        useReadableConsoleGit
+      )
   }
 }


### PR DESCRIPTION
## Summary
- Configure Git and DynamicVersioning helpers to use native git executable
- Fixes JGit's inability to handle git worktrees (NoWorkTreeException)
- Enables parallel development with multiple workers in separate worktrees

## Changes
- `helpers/Git.scala` - Added `useReadableConsoleGit` setting
- `helpers/DynamicVersioning.scala` - Added `useReadableConsoleGit` setting

## Test plan
- [x] Compiles successfully
- [x] Tested in synapify worktrees - workers can now run `sbt compile`

🤖 Generated with [Claude Code](https://claude.ai/code)